### PR TITLE
Consertado o erro de disposição das atividades e seções no firefox

### DIFF
--- a/Desenvolvimento/styles/base-style.css
+++ b/Desenvolvimento/styles/base-style.css
@@ -18,7 +18,6 @@ body, h1, h2, h3, h4, h5, h6, p, ol, ul {
 
 img {
     max-width: 100%;
-    height: 80%;
 }
 
 a {


### PR DESCRIPTION
O problema era simplesmente o CSS, o height:80% limitava a imagem até 80%, logo, os blocos das atividades ficavam em posições erradas, pois elas eram organizadas de forma fixa.